### PR TITLE
Add deserializer for CanFulfillIntentRequest

### DIFF
--- a/ask-sdk-model/ask_sdk_model/can_fulfill_intent_request.py
+++ b/ask-sdk-model/ask_sdk_model/can_fulfill_intent_request.py
@@ -1,0 +1,132 @@
+# coding: utf-8
+
+#
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+#
+
+import pprint
+import re  # noqa: F401
+import six
+import typing
+from enum import Enum
+from ask_sdk_model.request import Request
+
+
+if typing.TYPE_CHECKING:
+    from typing import Dict, List, Optional
+    from datetime import datetime
+    from ask_sdk_model.dialog_state import DialogState
+    from ask_sdk_model.intent import Intent
+
+
+class CanFulfillIntentRequest(Request):
+    """
+    An CanFulfillIntentRequest is an object that represents a request made to a skill based on what the user wants to do.
+
+
+    :param request_id: Represents the unique identifier for the specific request.
+    :type request_id: (optional) str
+    :param timestamp: Provides the date and time when Alexa sent the request as an ISO 8601 formatted string. Used to verify the request when hosting your skill as a web service.
+    :type timestamp: (optional) datetime
+    :param locale: A string indicating the user’s locale. For example: en-US.
+    :type locale: (optional) str
+    :param intent: An object that represents what the user wants.
+    :type intent: (optional) ask_sdk_model.intent.Intent
+
+    """
+    deserialized_types = {
+        'object_type': 'str',
+        'request_id': 'str',
+        'timestamp': 'datetime',
+        'locale': 'str',
+        'intent': 'ask_sdk_model.intent.Intent'
+    }
+
+    attribute_map = {
+        'object_type': 'type',
+        'request_id': 'requestId',
+        'timestamp': 'timestamp',
+        'locale': 'locale',
+        'intent': 'intent'
+    }
+
+    def __init__(self, request_id=None, timestamp=None, locale=None, intent=None):
+        # type: (Optional[str], Optional[datetime], Optional[str], Optional[Intent]) -> None
+        """An CanFulfillIntentRequest is an object that represents a request made to a skill based on what the user wants to do.
+
+        :param request_id: Represents the unique identifier for the specific request.
+        :type request_id: (optional) str
+        :param timestamp: Provides the date and time when Alexa sent the request as an ISO 8601 formatted string. Used to verify the request when hosting your skill as a web service.
+        :type timestamp: (optional) datetime
+        :param locale: A string indicating the user’s locale. For example: en-US.
+        :type locale: (optional) str
+        :param intent: An object that represents what the user wants.
+        :type intent: (optional) ask_sdk_model.intent.Intent
+        """
+        self.__discriminator_value = "CanFulfillIntentRequest"
+
+        self.object_type = self.__discriminator_value
+        super(CanFulfillIntentRequest, self).__init__(object_type=self.__discriminator_value, request_id=request_id, timestamp=timestamp, locale=locale)
+        self.intent = intent
+
+    def to_dict(self):
+        # type: () -> Dict[str, object]
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.deserialized_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else
+                    x.value if isinstance(x, Enum) else x,
+                    value
+                ))
+            elif isinstance(value, Enum):
+                result[attr] = value.value
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else
+                    (item[0], item[1].value)
+                    if isinstance(item[1], Enum) else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        # type: () -> str
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        # type: () -> str
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        # type: (object) -> bool
+        """Returns true if both objects are equal"""
+        if not isinstance(other, CanFulfillIntentRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        # type: (object) -> bool
+        """Returns true if both objects are not equal"""
+        return not self == other

--- a/ask-sdk-model/ask_sdk_model/request.py
+++ b/ask-sdk-model/ask_sdk_model/request.py
@@ -63,6 +63,8 @@ class Request(object):
         |
         | IntentRequest: :py:class:`ask_sdk_model.intent_request.IntentRequest`,
         |
+        | CanFulfillIntentRequest: :py:class:`ask_sdk_model.can_fulfill_intent_request.CanFulfillIntentRequest`,
+        |
         | AudioPlayer.PlaybackFailed: :py:class:`ask_sdk_model.interfaces.audioplayer.playback_failed_request.PlaybackFailedRequest`,
         |
         | LaunchRequest: :py:class:`ask_sdk_model.launch_request.LaunchRequest`,
@@ -128,6 +130,7 @@ class Request(object):
         'AlexaHouseholdListEvent.ItemsCreated': 'ask_sdk_model.services.list_management.list_items_created_event_request.ListItemsCreatedEventRequest',
         'SessionEndedRequest': 'ask_sdk_model.session_ended_request.SessionEndedRequest',
         'IntentRequest': 'ask_sdk_model.intent_request.IntentRequest',
+        'CanFulfillIntentRequest': 'ask_sdk_model.can_fulfill_intent_request.CanFulfillIntentRequest',
         'AudioPlayer.PlaybackFailed': 'ask_sdk_model.interfaces.audioplayer.playback_failed_request.PlaybackFailedRequest',
         'LaunchRequest': 'ask_sdk_model.launch_request.LaunchRequest',
         'AudioPlayer.PlaybackStopped': 'ask_sdk_model.interfaces.audioplayer.playback_stopped_request.PlaybackStoppedRequest',


### PR DESCRIPTION
## Description
Adds a deserializer for CanFulfillIntentRequests.
_Previous PR was accidentally submitted before I filled out the description, and I was unable to edit it once submitted._

## Testing
Ran it locally using pytest. Imported the handler and passed the request in, and asserted the canFulfillIntent response object.

## Motivation and Context
Without this, it's impossible to accept CanFulfillIntentRequests.

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] The change is generic and can be done across all model classes.
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
